### PR TITLE
zip バックエンドの複数サポート (rubyzip)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "jquery-rails"
 
 # To use debugger
 # gem 'debugger'
-gem 'zipruby'
 gem 'activerecord-import'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     ken_all (0.1.9)
       activerecord-import (~> 0.4)
       rails (>= 3.0.9)
-      zipruby
 
 GEM
   remote: http://rubygems.org/
@@ -104,7 +103,6 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.37)
-    zipruby (0.3.6)
 
 PLATFORMS
   ruby
@@ -117,4 +115,3 @@ DEPENDENCIES
   rr (~> 1.0.0)
   rspec-rails
   sqlite3
-  zipruby

--- a/ken_all.gemspec
+++ b/ken_all.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc","Gemfile","Gemfile.lock"]
 
   s.add_dependency "activerecord-import","~> 0.4"
-  s.add_dependency "zipruby",">= 0"
   s.add_dependency "rails", ">= 3.0.9"
 
   s.add_development_dependency "sqlite3"

--- a/lib/ken_all.rb
+++ b/lib/ken_all.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'open-uri'
 require 'tempfile'
-require 'zipruby'
 require 'csv'
 require 'curses'
 require 'activerecord-import'


### PR DESCRIPTION
ライブラリを作っていただきありがとうございます。
便利に利用させていただいてます。

この Pull Request はちょっと微妙な提案なのですが、import 時に使われる
zip ライブラリを rubyzip も使えるようにする物です。

取り込むかどうかの判断はお任せしますが、手元で困った事になったので
作成してみました。

なんでこんな物が必要かというと、rubyzip と zipruby が同じトップレベルの
名前空間 Zip を使っていて、何か他の gem が rubyzip に依存していると、rails
サーバの起動時にロードしようとして失敗してしまうためです。

そもそも同じトップレベルの名前空間使うなよ、と言う話ではあるのですが、
ken_all 側の zip ライブラリの利用がとても限定的なので、こちら側で対応
するのも良いかな、と思って変更を入れてみました。

どうでしょうか？
