### PR TITLE
Remove duplicate dependency on rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.1
+  - 2.2
 before_script:
   - cd spec/dummy
   - bundle exec rake db:setup

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source "http://rubygems.org"
 
 # Declare your gem's dependencies in ken_all.gemspec.
 gemspec
+
+gem 'rails', '~> 3.2'
+gem 'test-unit', '~> 3.0' # Ruby 2.2+ has removed test/unit from the core library. Rails requires this as a dependency.

--- a/ken_all.gemspec
+++ b/ken_all.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rr", "~> 1.1"
-  s.add_development_dependency "rails", "~> 3.2"
 end


### PR DESCRIPTION
最近のbundlerだとrake task実行時にgemspecがvalidationエラーになるので修正しました :)

- development/test でのRailsバージョンの指定をgemspecからGemfileに移動
- Ruby 2.1.x と Ruby 2.2.x でテスト

```bash
$ bundler -v
Bundler version 1.10.2

$ rake ken_all:import
The gemspec at ~/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/ken_all-bc525d017cd6/ken_all.gemspec is not valid. The validation error was 'duplicate dependency on rails (~> 3.2, development), (>= 3.0.9) use:
    add_runtime_dependency 'rails', '~> 3.2', '>= 3.0.9'
'
```

あと、新しいバージョンをreleaseしていただけると嬉しいです :bow: 