### PR TITLE
Allow to use rubyzip 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in ken_all.gemspec.
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activerecord-import (~> 0.4)
       curses (~> 1.0)
       rails (>= 3.0.9)
-      rubyzip (~> 1.2)
+      rubyzip (>= 1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -133,7 +133,7 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (2.0.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       rubyzip (~> 1.2)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actioncable (5.2.0)
       actionpack (= 5.2.0)

--- a/ken_all.gemspec
+++ b/ken_all.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activerecord-import","~> 0.4"
   s.add_dependency "rails", ">= 3.0.9"
-  s.add_dependency "rubyzip", '~> 1.2'
+  s.add_dependency "rubyzip", '>= 1.2'
   s.add_dependency "curses", '~> 1.0'
   s.add_development_dependency 'listen'
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
rubyzipが2.0.0がリリースされたので、2.0.0が使用出来るようバージョン指定を修正しました。
https://github.com/rubyzip/rubyzip/blob/master/Changelog.md#200-2019-09-25

rubyzipでセキュリティに関するデフォルトオプションの変更が含まれている為、お手隙の際にご確認及びリリースについてご検討頂けると助かります。
ご参考: https://github.com/rubyzip/rubyzip/pull/403