### PR TITLE
Fix the warning of URI.open

### DIFF
--- a/lib/ken_all/import.rb
+++ b/lib/ken_all/import.rb
@@ -5,7 +5,7 @@ module KenAll
   end
 
   class Import
-    URI = "http://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip"
+    FILE_URI = "http://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip"
 
     def initialize(opt = { visualize: true })
       @visualizer = KenAll::Visualizer.new(opt[:visualize])
@@ -49,7 +49,7 @@ module KenAll
     def download_file(file)
       @visualizer.download_status do
         file.binmode
-        open(URI, 'rb') do |read_file|
+        URI.open(FILE_URI, 'rb') do |read_file|
           file.write(read_file.read)
         end
         file.rewind


### PR DESCRIPTION
In Ruby 2.7.x, `bin/rails ken_all:import` displays a warning as below:

```bash
******** KEN_ALL ********
Welcome to amazing world.
+download
+unzip
+import
*************************/Users/tatsuya/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/ken_all-0.4.0/lib/ken_all/import.rb:52: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```

As mentioned in the warning, calling URI.open via Kernel#open is deprecated in Ruby 2.7.

This PR fixes the warning.